### PR TITLE
WT-5577 Add custom clang tidy check for alphabetical same line declarations

### DIFF
--- a/clang-tools-extra/clang-tidy/misc/AlphabeticalDeclOrderCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/AlphabeticalDeclOrderCheck.cpp
@@ -17,7 +17,6 @@ namespace tidy {
 namespace misc {
 
 void AlphabeticalDeclOrderCheck::registerMatchers(MatchFinder *Finder) {
-  // FIXME: Add matchers.
   Finder->addMatcher(declStmt().bind("stmt"), this);
 }
 
@@ -26,8 +25,6 @@ bool AlphabeticalDeclOrderCheck::checkAlphabeticalOrder(const DeclStmt *MatchedS
   auto it = MatchedStmt->decl_begin();
   auto firstVarDecl = dyn_cast<VarDecl>(*MatchedStmt->decl_begin());
   bool found = true;
-  
-
   
   DeclNames.push_back(firstVarDecl->getName());
   ++it;
@@ -49,7 +46,6 @@ bool AlphabeticalDeclOrderCheck::checkAlphabeticalOrder(const DeclStmt *MatchedS
 }
 
 void AlphabeticalDeclOrderCheck::check(const MatchFinder::MatchResult &Result) {
-  // FIXME: Add callback implementation.
   std::vector<StringRef> ret;
   const auto *MatchedStmt = Result.Nodes.getNodeAs<DeclStmt>("stmt");
   bool fixDecl = true;
@@ -63,7 +59,6 @@ void AlphabeticalDeclOrderCheck::check(const MatchFinder::MatchResult &Result) {
   }
 
   if (!checkAlphabeticalOrder(MatchedStmt, ret, fixDecl)) {
-
     auto MyDiag = diag(MatchedStmt->getBeginLoc(), "declaration name is out of order");
     if (fixDecl == false)
       return;

--- a/clang-tools-extra/clang-tidy/misc/AlphabeticalDeclOrderCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/AlphabeticalDeclOrderCheck.cpp
@@ -58,11 +58,12 @@ void AlphabeticalDeclOrderCheck::check(const MatchFinder::MatchResult &Result) {
     return;  
   }
 
-  if (!checkAlphabeticalOrder(MatchedStmt, ret, fixDecl)) {
+  if (!checkAlphabeticalOrder(MatchedStmt, ret, fixDecl)) {:
     auto MyDiag = diag(MatchedStmt->getBeginLoc(), "declaration name is out of order");
     if (fixDecl == false)
       return;
 
+    //Add suggestions on how to fix the alphabetical order
     std:: sort(ret.begin(), ret.end());
     auto itStmt = MatchedStmt->decl_begin();
     auto itVec = ret.begin();
@@ -72,9 +73,7 @@ void AlphabeticalDeclOrderCheck::check(const MatchFinder::MatchResult &Result) {
         continue;
 
       SourceRange RemovalRange(varDecl->getLocation());
-
       MyDiag << FixItHint::CreateReplacement(RemovalRange, (*itVec).str());
-
     }
   }
   

--- a/clang-tools-extra/clang-tidy/misc/AlphabeticalDeclOrderCheck.cpp
+++ b/clang-tools-extra/clang-tidy/misc/AlphabeticalDeclOrderCheck.cpp
@@ -1,0 +1,90 @@
+//===--- AlphabeticalDeclOrderCheck.cpp - clang-tidy ----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "AlphabeticalDeclOrderCheck.h"
+#include "clang/AST/ASTContext.h"
+#include "clang/ASTMatchers/ASTMatchFinder.h"
+
+using namespace clang::ast_matchers;
+
+namespace clang {
+namespace tidy {
+namespace misc {
+
+void AlphabeticalDeclOrderCheck::registerMatchers(MatchFinder *Finder) {
+  // FIXME: Add matchers.
+  Finder->addMatcher(declStmt().bind("stmt"), this);
+}
+
+bool AlphabeticalDeclOrderCheck::checkAlphabeticalOrder(const DeclStmt *MatchedStmt, std::vector<StringRef> &DeclNames, bool &fixDecl) {
+  auto prev_it = MatchedStmt->decl_begin();
+  auto it = MatchedStmt->decl_begin();
+  auto firstVarDecl = dyn_cast<VarDecl>(*MatchedStmt->decl_begin());
+  bool found = true;
+  
+
+  
+  DeclNames.push_back(firstVarDecl->getName());
+  ++it;
+  
+  while (it != MatchedStmt->decl_end()) {
+    auto varDecl = dyn_cast<VarDecl>(*it);
+    auto prevVarDecl = dyn_cast<VarDecl>(*prev_it);
+
+    if (varDecl->getName() < prevVarDecl->getName())
+      found = false;
+    if (varDecl->getType() != prevVarDecl->getType())
+      fixDecl = false;
+
+    DeclNames.push_back(varDecl->getName());
+    prev_it = it;
+    ++it;
+  }
+  return found;
+}
+
+void AlphabeticalDeclOrderCheck::check(const MatchFinder::MatchResult &Result) {
+  // FIXME: Add callback implementation.
+  std::vector<StringRef> ret;
+  const auto *MatchedStmt = Result.Nodes.getNodeAs<DeclStmt>("stmt");
+  bool fixDecl = true;
+
+  if (MatchedStmt->isSingleDecl())
+    return;
+
+  auto firstVarDecl = dyn_cast<VarDecl>(*MatchedStmt->decl_begin());
+  if (firstVarDecl ==  NULL) {
+    return;  
+  }
+
+  if (!checkAlphabeticalOrder(MatchedStmt, ret, fixDecl)) {
+
+    auto MyDiag = diag(MatchedStmt->getBeginLoc(), "declaration name is out of order");
+    if (fixDecl == false)
+      return;
+
+    std:: sort(ret.begin(), ret.end());
+    auto itStmt = MatchedStmt->decl_begin();
+    auto itVec = ret.begin();
+    for (;itStmt != MatchedStmt->decl_end() && itVec != ret.end();++itStmt, ++itVec) {
+      auto varDecl = dyn_cast<VarDecl>(*itStmt);
+      if (varDecl->getName() == *itVec)
+        continue;
+
+      SourceRange RemovalRange(varDecl->getLocation());
+
+      MyDiag << FixItHint::CreateReplacement(RemovalRange, (*itVec).str());
+
+    }
+  }
+  
+}
+
+} // namespace misc
+} // namespace tidy
+} // namespace clang

--- a/clang-tools-extra/clang-tidy/misc/AlphabeticalDeclOrderCheck.h
+++ b/clang-tools-extra/clang-tidy/misc/AlphabeticalDeclOrderCheck.h
@@ -15,10 +15,10 @@ namespace clang {
 namespace tidy {
 namespace misc {
 
-/// FIXME: Write a short description.
-///
-/// For the user-facing documentation see:
-/// http://clang.llvm.org/extra/clang-tidy/checks/misc-alphabetical-decl-order.html
+/// AlphabeticalDeclOrderCheck 
+///   Checks for alphabetical order on same line declarations. This provides
+///   FIXIT hints as well.
+/// Custom Added Check
 class AlphabeticalDeclOrderCheck : public ClangTidyCheck {
 public:
   AlphabeticalDeclOrderCheck(StringRef Name, ClangTidyContext *Context)

--- a/clang-tools-extra/clang-tidy/misc/AlphabeticalDeclOrderCheck.h
+++ b/clang-tools-extra/clang-tidy/misc/AlphabeticalDeclOrderCheck.h
@@ -1,0 +1,35 @@
+//===--- AlphabeticalDeclOrderCheck.h - clang-tidy --------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MISC_ALPHABETICALDECLORDERCHECK_H
+#define LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MISC_ALPHABETICALDECLORDERCHECK_H
+
+#include "../ClangTidyCheck.h"
+
+namespace clang {
+namespace tidy {
+namespace misc {
+
+/// FIXME: Write a short description.
+///
+/// For the user-facing documentation see:
+/// http://clang.llvm.org/extra/clang-tidy/checks/misc-alphabetical-decl-order.html
+class AlphabeticalDeclOrderCheck : public ClangTidyCheck {
+public:
+  AlphabeticalDeclOrderCheck(StringRef Name, ClangTidyContext *Context)
+      : ClangTidyCheck(Name, Context) {}
+  void registerMatchers(ast_matchers::MatchFinder *Finder) override;
+  void check(const ast_matchers::MatchFinder::MatchResult &Result) override;
+  bool checkAlphabeticalOrder(const DeclStmt *MatchedStmt, std::vector<StringRef> &DeclNames, bool &fixDecl);
+};
+
+} // namespace misc
+} // namespace tidy
+} // namespace clang
+
+#endif // LLVM_CLANG_TOOLS_EXTRA_CLANG_TIDY_MISC_ALPHABETICALDECLORDERCHECK_H

--- a/clang-tools-extra/clang-tidy/misc/CMakeLists.txt
+++ b/clang-tools-extra/clang-tidy/misc/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(LLVM_LINK_COMPONENTS support)
 
 add_clang_library(clangTidyMiscModule
+  AlphabeticalDeclOrderCheck.cpp
   DefinitionsInHeadersCheck.cpp
   MiscTidyModule.cpp
   MisplacedConstCheck.cpp

--- a/clang-tools-extra/clang-tidy/misc/MiscTidyModule.cpp
+++ b/clang-tools-extra/clang-tidy/misc/MiscTidyModule.cpp
@@ -9,6 +9,7 @@
 #include "../ClangTidy.h"
 #include "../ClangTidyModule.h"
 #include "../ClangTidyModuleRegistry.h"
+#include "AlphabeticalDeclOrderCheck.h"
 #include "DefinitionsInHeadersCheck.h"
 #include "MisplacedConstCheck.h"
 #include "NewDeleteOverloadsCheck.h"
@@ -30,6 +31,8 @@ namespace misc {
 class MiscModule : public ClangTidyModule {
 public:
   void addCheckFactories(ClangTidyCheckFactories &CheckFactories) override {
+    CheckFactories.registerCheck<AlphabeticalDeclOrderCheck>(
+        "misc-alphabetical-decl-order");
     CheckFactories.registerCheck<DefinitionsInHeadersCheck>(
         "misc-definitions-in-headers");
     CheckFactories.registerCheck<MisplacedConstCheck>("misc-misplaced-const");

--- a/clang-tools-extra/docs/ReleaseNotes.rst
+++ b/clang-tools-extra/docs/ReleaseNotes.rst
@@ -88,6 +88,12 @@ New checks
   Flags use of the `C` standard library functions ``memset``, ``memcpy`` and
   ``memcmp`` and similar derivatives on non-trivial types.
 
+- New :doc:`misc-alphabetical-decl-order
+  <clang-tidy/checks/misc-alphabetical-decl-order>` check.
+
+Checks and possibly fixes the same line declarations, to maintain alphabetical
+order.
+
 - New :doc:`objc-dealloc-in-category
   <clang-tidy/checks/objc-dealloc-in-category>` check.
 

--- a/clang-tools-extra/docs/clang-tidy/checks/list.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/list.rst
@@ -72,6 +72,7 @@ Clang-Tidy Checks
    `bugprone-not-null-terminated-result <bugprone-not-null-terminated-result.html>`_, "Yes"
    `bugprone-parent-virtual-call <bugprone-parent-virtual-call.html>`_, "Yes"
    `bugprone-posix-return <bugprone-posix-return.html>`_, "Yes"
+   `bugprone-reserved-identifier <bugprone-reserved-identifier.html>`_,
    `bugprone-signed-char-misuse <bugprone-signed-char-misuse.html>`_,
    `bugprone-sizeof-container <bugprone-sizeof-container.html>`_,
    `bugprone-sizeof-expression <bugprone-sizeof-expression.html>`_,
@@ -186,6 +187,7 @@ Clang-Tidy Checks
    `llvm-prefer-isa-or-dyn-cast-in-conditionals <llvm-prefer-isa-or-dyn-cast-in-conditionals.html>`_, "Yes"
    `llvm-prefer-register-over-unsigned <llvm-prefer-register-over-unsigned.html>`_, "Yes"
    `llvm-twine-local <llvm-twine-local.html>`_, "Yes"
+   `misc-alphabetical-decl-order <misc-alphabetical-decl-order.html>`_, "Yes"
    `misc-definitions-in-headers <misc-definitions-in-headers.html>`_, "Yes"
    `misc-misplaced-const <misc-misplaced-const.html>`_,
    `misc-new-delete-overloads <misc-new-delete-overloads.html>`_,
@@ -263,7 +265,7 @@ Clang-Tidy Checks
    `readability-deleted-default <readability-deleted-default.html>`_,
    `readability-else-after-return <readability-else-after-return.html>`_, "Yes"
    `readability-function-size <readability-function-size.html>`_,
-   `readability-identifier-naming <readability-identifier-naming.html>`_, "Yes"
+   `readability-identifier-naming <readability-identifier-naming.html>`_,
    `readability-implicit-bool-conversion <readability-implicit-bool-conversion.html>`_, "Yes"
    `readability-inconsistent-declaration-parameter-name <readability-inconsistent-declaration-parameter-name.html>`_, "Yes"
    `readability-isolate-declaration <readability-isolate-declaration.html>`_, "Yes"
@@ -298,6 +300,8 @@ Clang-Tidy Checks
 
    `cert-dcl03-c <cert-dcl03-c.html>`_, `misc-static-assert <misc-static-assert.html>`_, "Yes"
    `cert-dcl16-c <cert-dcl16-c.html>`_, `readability-uppercase-literal-suffix <readability-uppercase-literal-suffix.html>`_, "Yes"
+   `cert-dcl37-c <cert-dcl37-c.html>`_, `bugprone-reserved-identifier <bugprone-reserved-identifier.html>`_,
+   `cert-dcl51-cpp <cert-dcl51-cpp.html>`_, `bugprone-reserved-identifier <bugprone-reserved-identifier.html>`_,
    `cert-dcl54-cpp <cert-dcl54-cpp.html>`_, `misc-new-delete-overloads <misc-new-delete-overloads.html>`_,
    `cert-dcl59-cpp <cert-dcl59-cpp.html>`_, `google-build-namespaces <google-build-namespaces.html>`_,
    `cert-err09-cpp <cert-err09-cpp.html>`_, `misc-throw-by-value-catch-by-reference <misc-throw-by-value-catch-by-reference.html>`_,

--- a/clang-tools-extra/docs/clang-tidy/checks/misc-alphabetical-decl-order.rst
+++ b/clang-tools-extra/docs/clang-tidy/checks/misc-alphabetical-decl-order.rst
@@ -1,0 +1,8 @@
+.. title:: clang-tidy - misc-alphabetical-decl-order
+
+misc-alphabetical-decl-order
+============================
+
+Checks and possibly fixes the same line declarations, to maintain alphabetical
+order.
+E.g. int b, a, c --> int a, b, c

--- a/clang-tools-extra/test/clang-tidy/checkers/misc-alphabetical-decl-order.cpp
+++ b/clang-tools-extra/test/clang-tidy/checkers/misc-alphabetical-decl-order.cpp
@@ -1,0 +1,16 @@
+// RUN: %check_clang_tidy %s misc-alphabetical-decl-order %t
+
+// FIXME: Add something that triggers the check here.
+typedef struct node {
+    int data;
+    node* next;
+} node;
+
+void f() {
+    //Not ok
+    int b, a, c;
+    node bye, hi;
+
+    //Ok
+    int a, b, c;
+}


### PR DESCRIPTION
This PR adds another clang tidy custom check, and shows if the same line declarations are in alphabetical order or not. Also added the functionality to automatically fix the problems of only exact same types when using -fix flag in clang-tidy